### PR TITLE
Apply frontend-design skill: warm editorial UI redesign

### DIFF
--- a/medmate-ai/app/auth/login/page.tsx
+++ b/medmate-ai/app/auth/login/page.tsx
@@ -70,22 +70,22 @@ export default function LoginPage() {
   return (
     <div className="relative flex min-h-[calc(100vh-10rem)] items-center justify-center overflow-hidden px-4 py-12">
       {/* Background */}
-      <div className="absolute inset-0 -z-10 bg-dot-grid opacity-30 dark:opacity-10" />
-      <div className="absolute -left-40 -top-40 -z-10 h-80 w-80 rounded-full bg-teal-200/30 blur-3xl dark:bg-teal-800/20" />
-      <div className="absolute -bottom-40 -right-40 -z-10 h-80 w-80 rounded-full bg-amber-200/20 blur-3xl dark:bg-amber-800/10" />
+      <div className="absolute inset-0 -z-10 mesh-gradient" />
+      <div className="absolute -left-40 -top-40 -z-10 h-80 w-80 blob bg-ocean-200/30 blur-3xl dark:bg-ocean-800/20" />
+      <div className="absolute -bottom-40 -right-40 -z-10 h-80 w-80 blob bg-coral-200/20 blur-3xl dark:bg-coral-800/10" />
 
-      <Card className="w-full max-w-md animate-fade-in-up">
+      <Card className="w-full max-w-md animate-fade-up">
         <CardContent className="p-8">
           <div className="mb-8 flex flex-col items-center text-center">
             <div className="relative mb-4">
-              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-lg shadow-teal-500/25">
+              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-ocean-400 to-ocean-600 text-white shadow-lg shadow-ocean-500/25">
                 <Stethoscope className="h-7 w-7" />
               </div>
-              <div className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-lg bg-amber-400 shadow-md">
+              <div className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-lg bg-coral-400 shadow-md">
                 <Lock className="h-3 w-3 text-white" />
               </div>
             </div>
-            <h1 className="text-2xl font-bold">Welcome back</h1>
+            <h1 className="heading text-2xl font-bold">Welcome back</h1>
             <p className="mt-1.5 text-sm text-muted-foreground">
               Log in to access your health profile and consultation history.
             </p>
@@ -154,7 +154,7 @@ export default function LoginPage() {
             Don&apos;t have an account?{" "}
             <Link
               href="/auth/signup"
-              className="font-semibold text-teal-600 underline underline-offset-2 hover:text-teal-700 dark:text-teal-400"
+              className="font-semibold text-ocean-600 underline underline-offset-2 hover:text-ocean-700 dark:text-ocean-400"
             >
               Sign up
             </Link>

--- a/medmate-ai/app/auth/signup/page.tsx
+++ b/medmate-ai/app/auth/signup/page.tsx
@@ -67,22 +67,22 @@ export default function SignupPage() {
   return (
     <div className="relative flex min-h-[calc(100vh-10rem)] items-center justify-center overflow-hidden px-4 py-12">
       {/* Background */}
-      <div className="absolute inset-0 -z-10 bg-dot-grid opacity-30 dark:opacity-10" />
-      <div className="absolute -right-40 -top-40 -z-10 h-80 w-80 rounded-full bg-teal-200/30 blur-3xl dark:bg-teal-800/20" />
-      <div className="absolute -bottom-40 -left-40 -z-10 h-80 w-80 rounded-full bg-amber-200/20 blur-3xl dark:bg-amber-800/10" />
+      <div className="absolute inset-0 -z-10 mesh-gradient" />
+      <div className="absolute -right-40 -top-40 -z-10 h-80 w-80 blob bg-ocean-200/30 blur-3xl dark:bg-ocean-800/20" />
+      <div className="absolute -bottom-40 -left-40 -z-10 h-80 w-80 blob bg-coral-200/20 blur-3xl dark:bg-coral-800/10" />
 
-      <Card className="w-full max-w-md animate-fade-in-up">
+      <Card className="w-full max-w-md animate-fade-up">
         <CardContent className="p-8">
           <div className="mb-8 flex flex-col items-center text-center">
             <div className="relative mb-4">
-              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-lg shadow-teal-500/25">
+              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-ocean-400 to-ocean-600 text-white shadow-lg shadow-ocean-500/25">
                 <Stethoscope className="h-7 w-7" />
               </div>
-              <div className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-lg bg-amber-400 shadow-md">
+              <div className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-lg bg-coral-400 shadow-md">
                 <UserPlus className="h-3 w-3 text-white" />
               </div>
             </div>
-            <h1 className="text-2xl font-bold">Create your MedMate account</h1>
+            <h1 className="heading text-2xl font-bold">Create your MedMate account</h1>
             <p className="mt-1.5 text-sm text-muted-foreground">
               Free forever. Save your health profile and consultation history.
             </p>
@@ -132,21 +132,21 @@ export default function SignupPage() {
                 type="checkbox"
                 checked={accepted}
                 onChange={(e) => setAccepted(e.target.checked)}
-                className="mt-0.5 h-4 w-4 rounded border-border text-teal-500 focus:ring-teal-500"
+                className="mt-0.5 h-4 w-4 rounded border-border text-ocean-500 focus:ring-ocean-500"
               />
               <span className="leading-relaxed">
                 I understand that MedMate AI is not a doctor and does not provide
                 medical advice. I accept the{" "}
                 <Link
                   href="/terms"
-                  className="text-teal-600 underline underline-offset-2 hover:text-teal-700 dark:text-teal-400"
+                  className="text-ocean-600 underline underline-offset-2 hover:text-ocean-700 dark:text-ocean-400"
                 >
                   Terms of Service
                 </Link>{" "}
                 and{" "}
                 <Link
                   href="/privacy"
-                  className="text-teal-600 underline underline-offset-2 hover:text-teal-700 dark:text-teal-400"
+                  className="text-ocean-600 underline underline-offset-2 hover:text-ocean-700 dark:text-ocean-400"
                 >
                   Privacy Policy
                 </Link>
@@ -160,7 +160,7 @@ export default function SignupPage() {
               </div>
             )}
             {success && (
-              <div className="flex items-center gap-2 rounded-xl border border-teal-200 bg-teal-50 p-3 text-sm text-teal-700 dark:border-teal-900/40 dark:bg-teal-950/30 dark:text-teal-200">
+              <div className="flex items-center gap-2 rounded-xl border border-ocean-200 bg-ocean-50 p-3 text-sm text-ocean-700 dark:border-ocean-900/40 dark:bg-ocean-950/30 dark:text-ocean-200">
                 <CheckCircle2 className="h-4 w-4 shrink-0" />
                 Account created. Check your email to verify, then log in.
               </div>
@@ -176,7 +176,7 @@ export default function SignupPage() {
             Already have an account?{" "}
             <Link
               href="/auth/login"
-              className="font-semibold text-teal-600 underline underline-offset-2 hover:text-teal-700 dark:text-teal-400"
+              className="font-semibold text-ocean-600 underline underline-offset-2 hover:text-ocean-700 dark:text-ocean-400"
             >
               Log in
             </Link>

--- a/medmate-ai/app/globals.css
+++ b/medmate-ai/app/globals.css
@@ -4,67 +4,66 @@
 
 @layer base {
   :root {
-    --background: 48 20% 98%;
-    --foreground: 197 30% 12%;
+    --background: 28 40% 98%;
+    --foreground: 220 30% 12%;
 
     --card: 0 0% 100%;
-    --card-foreground: 197 30% 12%;
+    --card-foreground: 220 30% 12%;
 
-    --primary: 184 80% 26%;
+    --primary: 180 82% 24%;
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 184 40% 94%;
-    --secondary-foreground: 184 80% 20%;
+    --secondary: 28 30% 94%;
+    --secondary-foreground: 180 60% 22%;
 
-    --muted: 200 15% 95%;
-    --muted-foreground: 200 10% 40%;
+    --muted: 28 20% 94%;
+    --muted-foreground: 220 10% 42%;
 
-    --accent: 184 40% 94%;
-    --accent-foreground: 184 80% 20%;
+    --accent: 28 30% 94%;
+    --accent-foreground: 180 60% 22%;
 
-    --destructive: 0 72% 51%;
+    --destructive: 8 72% 50%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 200 15% 90%;
-    --input: 200 15% 88%;
-    --ring: 184 80% 26%;
+    --border: 28 15% 88%;
+    --input: 28 15% 86%;
+    --ring: 180 82% 24%;
 
-    --radius: 0.75rem;
+    --radius: 0.875rem;
   }
 
   .dark {
-    --background: 200 25% 6%;
-    --foreground: 48 20% 96%;
+    --background: 222 30% 7%;
+    --foreground: 28 20% 94%;
 
-    --card: 200 25% 9%;
-    --card-foreground: 48 20% 96%;
+    --card: 222 30% 10%;
+    --card-foreground: 28 20% 94%;
 
-    --primary: 184 70% 40%;
-    --primary-foreground: 200 25% 6%;
+    --primary: 180 60% 42%;
+    --primary-foreground: 222 30% 7%;
 
-    --secondary: 200 25% 14%;
-    --secondary-foreground: 48 20% 96%;
+    --secondary: 222 25% 14%;
+    --secondary-foreground: 28 20% 94%;
 
-    --muted: 200 25% 12%;
-    --muted-foreground: 200 10% 60%;
+    --muted: 222 25% 12%;
+    --muted-foreground: 220 10% 58%;
 
-    --accent: 200 25% 14%;
-    --accent-foreground: 48 20% 96%;
+    --accent: 222 25% 14%;
+    --accent-foreground: 28 20% 94%;
 
-    --destructive: 0 62% 45%;
+    --destructive: 8 62% 42%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 200 25% 15%;
-    --input: 200 25% 15%;
-    --ring: 184 70% 40%;
+    --border: 222 25% 16%;
+    --input: 222 25% 16%;
+    --ring: 180 60% 42%;
   }
 
   * {
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground antialiased;
-    font-feature-settings: "rlig" 1, "calt" 1;
+    @apply bg-background text-foreground;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -74,111 +73,110 @@
     overflow-x: hidden;
   }
 
-  /* Better focus styles globally */
-  :focus-visible {
-    @apply outline-none ring-2 ring-teal-500/50 ring-offset-2 ring-offset-background;
-  }
-
-  /* Smooth scrollbar */
-  ::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
-  }
-  ::-webkit-scrollbar-track {
-    @apply bg-transparent;
-  }
-  ::-webkit-scrollbar-thumb {
-    @apply rounded-full bg-border;
-  }
-  ::-webkit-scrollbar-thumb:hover {
-    @apply bg-muted-foreground/30;
-  }
-
-  /* Selection colour */
+  /* Warm selection */
   ::selection {
-    @apply bg-teal-200/60 text-teal-900;
+    @apply bg-ocean-200/70 text-ocean-900;
   }
   .dark ::selection {
-    @apply bg-teal-700/50 text-teal-50;
+    @apply bg-ocean-700/50 text-ocean-50;
   }
+
+  /* Refined scrollbar */
+  ::-webkit-scrollbar { width: 5px; height: 5px; }
+  ::-webkit-scrollbar-track { @apply bg-transparent; }
+  ::-webkit-scrollbar-thumb { @apply rounded-full bg-ocean-200/60; }
+  ::-webkit-scrollbar-thumb:hover { @apply bg-ocean-300/60; }
+  .dark ::-webkit-scrollbar-thumb { @apply bg-ocean-800/60; }
 }
 
 @layer components {
-  /* Chat prose */
+  /* ── Film grain overlay ── */
+  .grain {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    pointer-events: none;
+    opacity: 0.03;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    background-repeat: repeat;
+    background-size: 128px 128px;
+    mix-blend-mode: overlay;
+  }
+  .dark .grain { opacity: 0.04; }
+
+  /* ── Organic blob shape ── */
+  .blob {
+    border-radius: 60% 40% 30% 70% / 60% 30% 70% 40%;
+    animation: blob-morph 8s ease-in-out infinite;
+  }
+
+  /* ── Mesh gradient hero ── */
+  .mesh-gradient {
+    background:
+      radial-gradient(ellipse 80% 60% at 20% 0%, rgba(11,110,110,0.12), transparent),
+      radial-gradient(ellipse 60% 40% at 80% 20%, rgba(232,115,90,0.08), transparent),
+      radial-gradient(ellipse 50% 50% at 50% 100%, rgba(74,140,74,0.06), transparent);
+  }
+  .dark .mesh-gradient {
+    background:
+      radial-gradient(ellipse 80% 60% at 20% 0%, rgba(11,110,110,0.25), transparent),
+      radial-gradient(ellipse 60% 40% at 80% 20%, rgba(232,115,90,0.12), transparent),
+      radial-gradient(ellipse 50% 50% at 50% 100%, rgba(74,140,74,0.08), transparent);
+  }
+
+  /* ── Warm glass ── */
+  .glass {
+    @apply bg-white/70 backdrop-blur-2xl backdrop-saturate-150;
+  }
+  .dark .glass {
+    @apply bg-background/70;
+  }
+
+  /* ── Editorial heading ── */
+  .heading {
+    @apply font-display tracking-tight;
+    font-optical-sizing: auto;
+  }
+
+  /* ── Staggered children ── */
+  .stagger > * { animation-fill-mode: both; }
+  .stagger > *:nth-child(1) { animation-delay: 0ms; }
+  .stagger > *:nth-child(2) { animation-delay: 80ms; }
+  .stagger > *:nth-child(3) { animation-delay: 160ms; }
+  .stagger > *:nth-child(4) { animation-delay: 240ms; }
+  .stagger > *:nth-child(5) { animation-delay: 320ms; }
+  .stagger > *:nth-child(6) { animation-delay: 400ms; }
+
+  /* ── Chat prose ── */
   .prose-chat {
-    @apply text-[15px] leading-relaxed;
+    @apply text-[15px] leading-[1.7] font-body;
   }
-  .prose-chat p {
-    @apply mb-3 last:mb-0;
-  }
-  .prose-chat ul {
-    @apply mb-3 list-disc pl-5;
-  }
-  .prose-chat ol {
-    @apply mb-3 list-decimal pl-5;
-  }
-  .prose-chat li {
-    @apply mb-1;
-  }
-  .prose-chat strong {
-    @apply font-semibold;
-  }
+  .prose-chat p { @apply mb-3 last:mb-0; }
+  .prose-chat ul { @apply mb-3 list-disc pl-5; }
+  .prose-chat ol { @apply mb-3 list-decimal pl-5; }
+  .prose-chat li { @apply mb-1; }
+  .prose-chat strong { @apply font-semibold; }
   .prose-chat code {
-    @apply rounded-md bg-muted px-1.5 py-0.5 text-[13px] font-mono;
+    @apply rounded-md bg-ocean-50 px-1.5 py-0.5 text-[13px] font-mono text-ocean-700 dark:bg-ocean-900/50 dark:text-ocean-200;
   }
-  .prose-chat h1,
-  .prose-chat h2,
-  .prose-chat h3 {
-    @apply mb-2 mt-4 font-semibold;
+  .prose-chat h1, .prose-chat h2, .prose-chat h3 {
+    @apply mb-2 mt-4 font-display font-semibold;
   }
   .prose-chat a {
-    @apply text-teal-600 underline underline-offset-2 hover:text-teal-700 dark:text-teal-400 dark:hover:text-teal-300;
+    @apply text-ocean-600 underline decoration-ocean-300 underline-offset-2 hover:decoration-ocean-500 dark:text-ocean-400;
   }
 
-  /* Glass panel */
-  .glass {
-    @apply bg-white/70 backdrop-blur-xl dark:bg-background/70;
+  /* ── Hover lift ── */
+  .lift {
+    @apply transition-all duration-300 ease-out;
   }
-
-  /* Shimmer skeleton loading */
-  .skeleton {
-    @apply bg-gradient-to-r from-muted via-muted/50 to-muted bg-[length:200%_100%] animate-shimmer rounded-lg;
-  }
-
-  /* Gradient text */
-  .text-gradient {
-    @apply bg-gradient-to-r from-teal-600 via-teal-500 to-teal-400 bg-clip-text text-transparent;
-  }
-  .dark .text-gradient {
-    @apply from-teal-400 via-teal-300 to-teal-200;
-  }
-
-  /* Glow ring on hover */
-  .hover-glow {
-    @apply transition-shadow duration-300 hover:shadow-glow;
-  }
-
-  /* Subtle card hover lift */
-  .hover-lift {
-    @apply transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-soft-lg;
-  }
-
-  /* Stagger children animations */
-  .stagger-children > *:nth-child(1) { animation-delay: 0ms; }
-  .stagger-children > *:nth-child(2) { animation-delay: 60ms; }
-  .stagger-children > *:nth-child(3) { animation-delay: 120ms; }
-  .stagger-children > *:nth-child(4) { animation-delay: 180ms; }
-  .stagger-children > *:nth-child(5) { animation-delay: 240ms; }
-  .stagger-children > *:nth-child(6) { animation-delay: 300ms; }
-  .stagger-children > * {
-    animation-fill-mode: both;
+  .lift:hover {
+    @apply -translate-y-1 shadow-warm-lg;
   }
 }
 
 @layer utilities {
-  /* Dot grid background */
-  .bg-dot-grid {
-    background-image: radial-gradient(circle, hsl(var(--border)) 1px, transparent 1px);
-    background-size: 24px 24px;
+  .text-balance {
+    text-wrap: balance;
   }
 }

--- a/medmate-ai/app/history/page.tsx
+++ b/medmate-ai/app/history/page.tsx
@@ -26,9 +26,9 @@ import type { Consultation, TriageLevel } from "@/types";
 const triageLabels: Record<TriageLevel, { label: string; cls: string }> = {
   emergency: { label: "Call 000", cls: "bg-red-100 text-red-800" },
   urgent: { label: "Emergency Dept", cls: "bg-orange-100 text-orange-800" },
-  "see-gp-soon": { label: "See GP soon", cls: "bg-amber-100 text-amber-900" },
-  telehealth: { label: "Telehealth", cls: "bg-teal-100 text-teal-800" },
-  "self-care": { label: "Self-care", cls: "bg-emerald-100 text-emerald-800" },
+  "see-gp-soon": { label: "See GP soon", cls: "bg-coral-100 text-coral-900" },
+  telehealth: { label: "Telehealth", cls: "bg-ocean-100 text-ocean-800" },
+  "self-care": { label: "Self-care", cls: "bg-sage-100 text-sage-800" },
 };
 
 export default function HistoryPage() {
@@ -129,11 +129,11 @@ export default function HistoryPage() {
   return (
     <div className="container max-w-3xl py-10">
       <div className="mb-8 flex items-center gap-3">
-        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-lg shadow-teal-500/25">
+        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-ocean-400 to-ocean-600 text-white shadow-lg shadow-ocean-500/25">
           <FileText className="h-6 w-6" />
         </div>
         <div>
-          <h1 className="text-2xl font-bold">Consultation history</h1>
+          <h1 className="heading text-2xl font-bold">Consultation history</h1>
           <p className="text-sm text-muted-foreground">
             Your past chats, summarised and searchable.
           </p>
@@ -223,10 +223,10 @@ function EmptyHistory() {
   return (
     <Card>
       <CardContent className="flex flex-col items-center gap-4 py-16 text-center">
-        <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-lg shadow-teal-500/20 animate-float-gentle">
+        <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-ocean-400 to-ocean-600 text-white shadow-lg shadow-ocean-500/20 animate-float">
           <Stethoscope className="h-7 w-7" />
         </div>
-        <h2 className="text-lg font-bold">No consultations yet</h2>
+        <h2 className="heading text-lg font-bold">No consultations yet</h2>
         <p className="max-w-sm text-sm text-muted-foreground">
           Your saved consultations will appear here. Start a chat with MedMate
           to get going.

--- a/medmate-ai/app/layout.tsx
+++ b/medmate-ai/app/layout.tsx
@@ -1,13 +1,20 @@
 import type { Metadata, Viewport } from "next";
-import { Inter } from "next/font/google";
+import { Fraunces, DM_Sans } from "next/font/google";
 import "./globals.css";
 import { Nav } from "@/components/layout/nav";
 import { Footer } from "@/components/layout/footer";
 import { DisclaimerBanner } from "@/components/layout/disclaimer-banner";
 
-const inter = Inter({
+const fraunces = Fraunces({
   subsets: ["latin"],
-  variable: "--font-inter",
+  variable: "--font-display",
+  display: "swap",
+  axes: ["opsz"],
+});
+
+const dmSans = DM_Sans({
+  subsets: ["latin"],
+  variable: "--font-body",
   display: "swap",
 });
 
@@ -40,8 +47,8 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#FAFAF9" },
-    { media: "(prefers-color-scheme: dark)", color: "#0D7377" },
+    { media: "(prefers-color-scheme: light)", color: "#FDF6F0" },
+    { media: "(prefers-color-scheme: dark)", color: "#0C1222" },
   ],
 };
 
@@ -52,7 +59,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en-AU" suppressHydrationWarning>
-      <body className={`${inter.variable} font-sans`}>
+      <body
+        className={`${fraunces.variable} ${dmSans.variable} font-body antialiased`}
+      >
+        <div className="grain" aria-hidden />
         <DisclaimerBanner />
         <Nav />
         <main className="min-h-[calc(100vh-8rem)]">{children}</main>

--- a/medmate-ai/app/page.tsx
+++ b/medmate-ai/app/page.tsx
@@ -21,37 +21,37 @@ const features = [
     icon: MessageSquareHeart,
     title: "AI Chat with an Australian GP mindset",
     body: "Describe your symptoms in plain language. MedMate asks the right clarifying questions and explains things the way a good Aussie GP would.",
-    accent: "from-teal-400 to-emerald-500",
+    accent: "from-ocean-400 to-ocean-600",
   },
   {
     icon: ClipboardList,
     title: "Guided symptom checker",
     body: "Step through body area, symptoms, duration and severity. Get a clear triage recommendation in minutes.",
-    accent: "from-blue-400 to-teal-500",
+    accent: "from-ocean-300 to-ocean-500",
   },
   {
     icon: User,
     title: "Health profile",
     body: "Save your conditions, medications and allergies once. MedMate personalises every response without asking again.",
-    accent: "from-violet-400 to-blue-500",
+    accent: "from-sage-400 to-sage-600",
   },
   {
     icon: Video,
     title: "Book a real telehealth consult",
     body: "If you need a doctor, book a telehealth appointment with an Australian GP. Bulk-billed when eligible.",
-    accent: "from-amber-400 to-orange-500",
+    accent: "from-coral-400 to-coral-600",
   },
   {
     icon: Shield,
     title: "Private by design",
     body: "Your conversations are yours. Encrypted in transit, stored securely, and never sold or used to train models.",
-    accent: "from-emerald-400 to-green-500",
+    accent: "from-sage-500 to-sage-700",
   },
   {
     icon: HeartPulse,
     title: "Built for Australia",
     body: "Knows Medicare, the PBS, Mental Health Care Plans, Chronic Disease Management, Healthdirect, 13HEALTH and more.",
-    accent: "from-rose-400 to-pink-500",
+    accent: "from-coral-500 to-coral-700",
   },
 ];
 
@@ -66,15 +66,15 @@ const pathways = [
   },
   {
     label: "See your GP in 24\u201348h",
-    tone: "bg-amber-50 text-amber-800 border-amber-200 dark:bg-amber-950/30 dark:text-amber-300 dark:border-amber-900/40",
+    tone: "bg-coral-50 text-coral-800 border-coral-200 dark:bg-coral-900/30 dark:text-coral-300 dark:border-coral-900/40",
   },
   {
     label: "Book telehealth",
-    tone: "bg-teal-50 text-teal-700 border-teal-200 dark:bg-teal-950/30 dark:text-teal-300 dark:border-teal-900/40",
+    tone: "bg-ocean-50 text-ocean-700 border-ocean-200 dark:bg-ocean-950/30 dark:text-ocean-300 dark:border-ocean-900/40",
   },
   {
     label: "Manage at home",
-    tone: "bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/30 dark:text-emerald-300 dark:border-emerald-900/40",
+    tone: "bg-sage-50 text-sage-700 border-sage-200 dark:bg-sage-900/30 dark:text-sage-300 dark:border-sage-900/40",
   },
 ];
 
@@ -114,13 +114,13 @@ export default function HomePage() {
     <div>
       {/* ─── Hero ─── */}
       <section className="relative overflow-hidden">
-        {/* Background layers */}
-        <div className="absolute inset-0 -z-10 bg-hero-pattern dark:bg-hero-pattern-dark" />
-        <div className="absolute inset-0 -z-10 bg-dot-grid opacity-[0.35] dark:opacity-[0.15]" />
+        {/* Mesh gradient background */}
+        <div className="absolute inset-0 -z-10 mesh-gradient" />
 
-        {/* Decorative blobs */}
-        <div className="absolute -right-40 -top-40 -z-10 h-80 w-80 rounded-full bg-teal-200/30 blur-3xl dark:bg-teal-800/20" />
-        <div className="absolute -left-32 top-1/2 -z-10 h-64 w-64 rounded-full bg-amber-200/20 blur-3xl dark:bg-amber-800/10" />
+        {/* Organic blob shapes */}
+        <div className="absolute -right-40 -top-40 -z-10 h-80 w-80 blob bg-ocean-200/30 blur-3xl dark:bg-ocean-800/20" />
+        <div className="absolute -left-32 top-1/2 -z-10 h-64 w-64 blob bg-coral-200/20 blur-3xl dark:bg-coral-800/10" aria-hidden />
+        <div className="absolute bottom-0 right-1/4 -z-10 h-48 w-48 blob bg-sage-200/20 blur-3xl dark:bg-sage-800/10" aria-hidden />
 
         <div className="container py-24 md:py-36">
           <div className="mx-auto max-w-3xl text-center">
@@ -128,21 +128,23 @@ export default function HomePage() {
               variant="secondary"
               className="mb-6 animate-fade-in px-4 py-1.5 text-xs"
             >
-              <Sparkles className="mr-1.5 h-3.5 w-3.5 text-amber-500" />
+              <Sparkles className="mr-1.5 h-3.5 w-3.5 text-coral-500" />
               Free &middot; Private &middot; 24/7
             </Badge>
 
-            <h1 className="animate-fade-in-up text-4xl font-extrabold tracking-tight sm:text-5xl md:text-6xl lg:text-7xl">
+            <h1 className="heading animate-fade-up text-4xl font-extrabold sm:text-5xl md:text-6xl lg:text-7xl">
               Your Personal AI Doctor,{" "}
-              <span className="text-gradient">Built&nbsp;for&nbsp;Australia</span>
+              <span className="bg-gradient-to-r from-ocean-500 via-ocean-400 to-sage-500 bg-clip-text text-transparent">
+                Built&nbsp;for&nbsp;Australia
+              </span>
             </h1>
 
-            <p className="mx-auto mt-6 max-w-2xl animate-fade-in-up text-lg leading-relaxed text-muted-foreground [animation-delay:100ms]">
+            <p className="mx-auto mt-6 max-w-2xl animate-fade-up text-lg leading-relaxed text-muted-foreground [animation-delay:100ms]">
               Free, private, 24/7 health guidance — designed around Medicare,
               the PBS, and how healthcare actually works here.
             </p>
 
-            <div className="mt-10 flex animate-fade-in-up flex-col items-center justify-center gap-3 [animation-delay:200ms] sm:flex-row">
+            <div className="mt-10 flex animate-fade-up flex-col items-center justify-center gap-3 [animation-delay:200ms] sm:flex-row">
               <Link href="/chat">
                 <Button size="xl" className="group w-full sm:w-auto">
                   Start a consultation
@@ -171,9 +173,9 @@ export default function HomePage() {
             {stats.map((s) => (
               <div
                 key={s.value}
-                className="flex flex-col items-center rounded-2xl border border-border/50 bg-card/60 px-4 py-5 text-center shadow-soft backdrop-blur-sm"
+                className="flex flex-col items-center rounded-2xl border border-border/50 bg-card/60 px-4 py-5 text-center shadow-warm backdrop-blur-sm"
               >
-                <span className="text-2xl font-bold text-teal-600 dark:text-teal-400">
+                <span className="heading text-2xl font-bold text-ocean-600 dark:text-ocean-400">
                   {s.value}
                 </span>
                 <span className="mt-1 text-xs text-muted-foreground">
@@ -206,12 +208,14 @@ export default function HomePage() {
       <section className="container py-24">
         <div className="mx-auto mb-14 max-w-2xl text-center">
           <Badge variant="secondary" className="mb-4">
-            <Zap className="mr-1.5 h-3 w-3 text-amber-500" />
+            <Zap className="mr-1.5 h-3 w-3 text-coral-500" />
             Everything you need
           </Badge>
-          <h2 className="text-3xl font-bold tracking-tight md:text-4xl">
+          <h2 className="heading text-3xl font-bold md:text-4xl">
             Health guidance that actually{" "}
-            <span className="text-gradient">understands Australia</span>
+            <span className="bg-gradient-to-r from-ocean-500 to-sage-500 bg-clip-text text-transparent">
+              understands Australia
+            </span>
           </h2>
           <p className="mt-4 text-muted-foreground">
             MedMate feels like a good conversation with a thoughtful Australian
@@ -220,11 +224,11 @@ export default function HomePage() {
           </p>
         </div>
 
-        <div className="stagger-children grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+        <div className="stagger grid gap-5 md:grid-cols-2 lg:grid-cols-3">
           {features.map((f) => (
             <Card
               key={f.title}
-              className="group animate-fade-in-up hover-lift cursor-default"
+              className="group lift animate-fade-up cursor-default"
             >
               <CardContent className="p-6">
                 <div
@@ -232,7 +236,7 @@ export default function HomePage() {
                 >
                   <f.icon className="h-5 w-5" />
                 </div>
-                <h3 className="mb-2 text-base font-semibold">{f.title}</h3>
+                <h3 className="heading mb-2 text-base font-semibold">{f.title}</h3>
                 <p className="text-sm leading-relaxed text-muted-foreground">
                   {f.body}
                 </p>
@@ -244,23 +248,22 @@ export default function HomePage() {
 
       {/* ─── Australia-focused section ─── */}
       <section className="relative overflow-hidden py-24">
-        <div className="absolute inset-0 -z-10 bg-gradient-to-br from-teal-600 via-teal-500 to-teal-700" />
-        <div className="absolute inset-0 -z-10 bg-dot-grid opacity-10" />
-        <div className="absolute -right-20 -top-20 -z-10 h-72 w-72 rounded-full bg-teal-300/20 blur-3xl" />
-        <div className="absolute -bottom-20 -left-20 -z-10 h-72 w-72 rounded-full bg-amber-300/10 blur-3xl" />
+        <div className="absolute inset-0 -z-10 bg-gradient-to-br from-ocean-600 via-ocean-500 to-ocean-700" />
+        <div className="absolute -right-20 -top-20 -z-10 h-72 w-72 blob bg-ocean-300/20 blur-3xl" />
+        <div className="absolute -bottom-20 -left-20 -z-10 h-72 w-72 blob bg-coral-300/10 blur-3xl" />
 
         <div className="container">
           <div className="grid items-center gap-12 md:grid-cols-2">
             <div>
-              <Badge className="mb-5 border-teal-300/30 bg-white/15 text-white backdrop-blur-sm">
+              <Badge className="mb-5 border-ocean-300/30 bg-white/15 text-white backdrop-blur-sm">
                 <HeartPulse className="mr-1.5 h-3 w-3" />
                 Australian-first
               </Badge>
-              <h2 className="text-3xl font-bold text-white md:text-4xl">
+              <h2 className="heading text-3xl font-bold text-white md:text-4xl">
                 Australia&apos;s healthcare system is world-class. MedMate helps
                 you navigate it.
               </h2>
-              <p className="mt-5 text-base leading-relaxed text-teal-50/90">
+              <p className="mt-5 text-base leading-relaxed text-ocean-50/90">
                 Knowing when to see a GP, when to go to ED, and when you need a
                 specialist referral is the hard part. MedMate is built around the
                 way care actually works here.
@@ -279,8 +282,8 @@ export default function HomePage() {
                   key={item}
                   className="flex items-start gap-3 rounded-xl bg-white/10 px-4 py-3 backdrop-blur-sm"
                 >
-                  <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-amber-300" />
-                  <span className="text-sm font-medium text-teal-50">
+                  <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-coral-300" />
+                  <span className="text-sm font-medium text-ocean-50">
                     {item}
                   </span>
                 </li>
@@ -294,10 +297,10 @@ export default function HomePage() {
       <section className="container py-24">
         <div className="mx-auto mb-14 max-w-2xl text-center">
           <Badge variant="secondary" className="mb-4">
-            <Star className="mr-1.5 h-3 w-3 text-amber-500" />
+            <Star className="mr-1.5 h-3 w-3 text-coral-500" />
             What people say
           </Badge>
-          <h2 className="text-3xl font-bold tracking-tight md:text-4xl">
+          <h2 className="heading text-3xl font-bold tracking-tight md:text-4xl">
             Trusted by Australians, everywhere
           </h2>
           <p className="mt-4 text-muted-foreground">
@@ -306,11 +309,11 @@ export default function HomePage() {
           </p>
         </div>
 
-        <div className="stagger-children grid gap-6 md:grid-cols-3">
+        <div className="stagger grid gap-6 md:grid-cols-3">
           {testimonials.map((t) => (
             <Card
               key={t.name}
-              className="group animate-fade-in-up hover-lift cursor-default"
+              className="group lift animate-fade-up cursor-default"
             >
               <CardContent className="flex h-full flex-col p-6">
                 {/* Stars */}
@@ -318,7 +321,7 @@ export default function HomePage() {
                   {Array.from({ length: t.stars }).map((_, i) => (
                     <Star
                       key={i}
-                      className="h-4 w-4 fill-amber-400 text-amber-400"
+                      className="h-4 w-4 fill-coral-400 text-coral-400"
                     />
                   ))}
                 </div>
@@ -326,7 +329,7 @@ export default function HomePage() {
                   &ldquo;{t.quote}&rdquo;
                 </p>
                 <div className="mt-5 flex items-center gap-3 border-t border-border/40 pt-4">
-                  <div className="flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-br from-teal-400 to-teal-600 text-xs font-bold text-white">
+                  <div className="flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-br from-ocean-400 to-ocean-600 text-xs font-bold text-white">
                     {t.name[0]}
                   </div>
                   <div>
@@ -344,17 +347,17 @@ export default function HomePage() {
 
       {/* ─── CTA ─── */}
       <section className="container pb-24">
-        <Card className="relative overflow-hidden border-teal-200/50 dark:border-teal-800/40">
+        <Card className="relative overflow-hidden border-ocean-200/50 dark:border-ocean-800/40">
           {/* Background */}
-          <div className="absolute inset-0 bg-gradient-to-br from-teal-50 via-background to-amber-50/30 dark:from-teal-950/30 dark:via-background dark:to-amber-950/10" />
-          <div className="absolute -right-32 -top-32 h-64 w-64 rounded-full bg-teal-200/30 blur-3xl dark:bg-teal-800/15" />
-          <div className="absolute -bottom-32 -left-32 h-64 w-64 rounded-full bg-amber-200/20 blur-3xl dark:bg-amber-800/10" />
+          <div className="absolute inset-0 bg-gradient-to-br from-ocean-50 via-background to-coral-50/30 dark:from-ocean-950/30 dark:via-background dark:to-coral-950/10" />
+          <div className="absolute -right-32 -top-32 h-64 w-64 blob bg-ocean-200/30 blur-3xl dark:bg-ocean-800/15" />
+          <div className="absolute -bottom-32 -left-32 h-64 w-64 blob bg-coral-200/20 blur-3xl dark:bg-coral-800/10" />
 
           <CardContent className="relative p-10 text-center md:p-16">
-            <div className="mx-auto mb-6 flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-lg shadow-teal-500/25 animate-float-gentle">
+            <div className="mx-auto mb-6 flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-ocean-400 to-ocean-600 text-white shadow-lg shadow-ocean-500/25 animate-float">
               <MessageSquareHeart className="h-7 w-7" />
             </div>
-            <h2 className="text-3xl font-bold tracking-tight md:text-4xl">
+            <h2 className="heading text-3xl font-bold tracking-tight md:text-4xl">
               Got a health question right now?
             </h2>
             <p className="mx-auto mt-4 max-w-xl text-muted-foreground">

--- a/medmate-ai/app/profile/page.tsx
+++ b/medmate-ai/app/profile/page.tsx
@@ -113,11 +113,11 @@ export default function ProfilePage() {
   return (
     <div className="container max-w-3xl py-10">
       <div className="mb-8 flex items-center gap-3">
-        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-lg shadow-teal-500/25">
+        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-ocean-400 to-ocean-600 text-white shadow-lg shadow-ocean-500/25">
           <User className="h-6 w-6" />
         </div>
         <div>
-          <h1 className="text-2xl font-bold">Your health profile</h1>
+          <h1 className="heading text-2xl font-bold">Your health profile</h1>
           <p className="text-sm text-muted-foreground">
             MedMate uses this to personalise every consultation.
           </p>
@@ -158,7 +158,7 @@ export default function ProfilePage() {
             </Field>
             <Field label="Sex assigned at birth">
               <select
-                className="flex h-10 w-full rounded-lg border border-border bg-background px-3 text-sm"
+                className="flex h-10 w-full rounded-xl border border-border bg-background px-3 font-body text-sm transition-colors hover:border-ocean-300 focus:outline-none focus:ring-2 focus:ring-ocean-500/30"
                 value={profile.sex ?? ""}
                 onChange={(e) =>
                   setProfile({
@@ -176,7 +176,7 @@ export default function ProfilePage() {
             </Field>
             <Field label="Blood type">
               <select
-                className="flex h-10 w-full rounded-lg border border-border bg-background px-3 text-sm"
+                className="flex h-10 w-full rounded-xl border border-border bg-background px-3 font-body text-sm transition-colors hover:border-ocean-300 focus:outline-none focus:ring-2 focus:ring-ocean-500/30"
                 value={profile.bloodType ?? "unknown"}
                 onChange={(e) =>
                   setProfile({
@@ -315,7 +315,7 @@ export default function ProfilePage() {
 
         <div className="flex items-center justify-end gap-3">
           {message && (
-            <span className="text-sm text-teal-600">{message}</span>
+            <span className="text-sm text-ocean-600">{message}</span>
           )}
           <Button onClick={handleSave} disabled={saving}>
             {saving ? (
@@ -379,13 +379,13 @@ function ListCard({
           {items.map((item, i) => (
             <span
               key={`${item}-${i}`}
-              className="inline-flex items-center gap-1.5 rounded-full border border-teal-200/60 bg-gradient-to-r from-teal-50 to-teal-50/50 px-3 py-1.5 text-sm font-medium text-teal-700 shadow-sm dark:border-teal-800/60 dark:from-teal-900/40 dark:to-teal-900/20 dark:text-teal-200"
+              className="inline-flex items-center gap-1.5 rounded-full border border-ocean-200/60 bg-gradient-to-r from-ocean-50 to-ocean-50/50 px-3 py-1.5 text-sm font-medium text-ocean-700 shadow-sm dark:border-ocean-800/60 dark:from-ocean-900/40 dark:to-ocean-900/20 dark:text-ocean-200"
             >
               {item}
               <button
                 type="button"
                 onClick={() => onChange(items.filter((_, j) => j !== i))}
-                className="rounded-full hover:bg-teal-100 dark:hover:bg-teal-800"
+                className="rounded-full hover:bg-ocean-100 dark:hover:bg-ocean-800"
                 aria-label={`Remove ${item}`}
               >
                 <X className="h-3 w-3" />

--- a/medmate-ai/app/symptom-checker/page.tsx
+++ b/medmate-ai/app/symptom-checker/page.tsx
@@ -112,7 +112,6 @@ export default function SymptomCheckerPage() {
 
   function goToChat() {
     const summary = buildSummary(input);
-    // Store in sessionStorage for the chat page to pick up
     if (typeof window !== "undefined") {
       sessionStorage.setItem("medmate:symptom-input", summary);
     }
@@ -127,12 +126,12 @@ export default function SymptomCheckerPage() {
     <div className="container max-w-2xl py-10">
       <div className="mb-8 flex items-center gap-3">
         <div className="relative">
-          <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-lg shadow-teal-500/25">
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-ocean-400 to-ocean-600 text-white shadow-lg shadow-ocean-500/25">
             <ClipboardList className="h-6 w-6" />
           </div>
         </div>
         <div>
-          <h1 className="text-2xl font-bold">Symptom checker</h1>
+          <h1 className="heading text-2xl font-bold">Symptom checker</h1>
           <p className="text-sm text-muted-foreground">
             A quick, guided walkthrough to help MedMate triage your concern.
           </p>
@@ -148,15 +147,15 @@ export default function SymptomCheckerPage() {
           >
             <div className="flex items-center gap-0 w-full">
               {i > 0 && (
-                <div className={cn("h-0.5 flex-1 rounded-full transition-colors", step >= s.num ? "bg-teal-400" : "bg-border")} />
+                <div className={cn("h-0.5 flex-1 rounded-full transition-colors", step >= s.num ? "bg-ocean-400" : "bg-border")} />
               )}
               <div
                 className={cn(
                   "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-xs font-semibold transition-all duration-300",
                   step > s.num &&
-                    "bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-md shadow-teal-500/20",
+                    "bg-gradient-to-br from-ocean-400 to-ocean-600 text-white shadow-md shadow-ocean-500/20",
                   step === s.num &&
-                    "border-2 border-teal-500 bg-teal-50 text-teal-600 shadow-glow dark:bg-teal-900/30 dark:text-teal-200",
+                    "border-2 border-ocean-500 bg-ocean-50 text-ocean-600 shadow-glow dark:bg-ocean-900/30 dark:text-ocean-200",
                   step < s.num &&
                     "border border-border bg-background text-muted-foreground",
                 )}
@@ -164,13 +163,13 @@ export default function SymptomCheckerPage() {
                 {step > s.num ? <CheckCircle2 className="h-4 w-4" /> : s.num}
               </div>
               {i < STEPS.length - 1 && (
-                <div className={cn("h-0.5 flex-1 rounded-full transition-colors", step > s.num ? "bg-teal-400" : "bg-border")} />
+                <div className={cn("h-0.5 flex-1 rounded-full transition-colors", step > s.num ? "bg-ocean-400" : "bg-border")} />
               )}
             </div>
             <span
               className={cn(
                 "hidden text-[11px] md:block",
-                step === s.num ? "font-semibold text-teal-600 dark:text-teal-400" : "text-muted-foreground",
+                step === s.num ? "font-semibold text-ocean-600 dark:text-ocean-400" : "text-muted-foreground",
               )}
             >
               {s.label}
@@ -196,8 +195,8 @@ export default function SymptomCheckerPage() {
                   className={cn(
                     "rounded-xl border p-3.5 text-left text-sm font-medium transition-all duration-200",
                     input.bodyArea === area
-                      ? "border-teal-400 bg-gradient-to-r from-teal-50 to-teal-50/50 text-teal-700 shadow-glow dark:from-teal-900/30 dark:to-teal-900/10 dark:text-teal-200"
-                      : "border-border/60 hover:-translate-y-0.5 hover:border-teal-300 hover:shadow-soft dark:hover:border-teal-700",
+                      ? "border-ocean-400 bg-gradient-to-r from-ocean-50 to-ocean-50/50 text-ocean-700 shadow-glow dark:from-ocean-900/30 dark:to-ocean-900/10 dark:text-ocean-200"
+                      : "border-border/60 hover:-translate-y-0.5 hover:border-ocean-300 hover:shadow-warm dark:hover:border-ocean-700",
                   )}
                 >
                   {area}
@@ -228,8 +227,8 @@ export default function SymptomCheckerPage() {
                       className={cn(
                         "rounded-full border px-3.5 py-1.5 text-sm font-medium transition-all duration-200",
                         active
-                          ? "border-teal-400 bg-gradient-to-r from-teal-500 to-teal-600 text-white shadow-md shadow-teal-500/20"
-                          : "border-border/60 hover:border-teal-300 hover:bg-teal-50 dark:hover:border-teal-700 dark:hover:bg-teal-900/20",
+                          ? "border-ocean-400 bg-gradient-to-r from-ocean-500 to-ocean-600 text-white shadow-md shadow-ocean-500/20"
+                          : "border-border/60 hover:border-ocean-300 hover:bg-ocean-50 dark:hover:border-ocean-700 dark:hover:bg-ocean-900/20",
                       )}
                     >
                       {sym}
@@ -284,8 +283,8 @@ export default function SymptomCheckerPage() {
                       className={cn(
                         "h-12 flex-1 rounded-xl border text-sm font-semibold transition-all duration-200",
                         input.severity === n
-                          ? "border-teal-400 bg-gradient-to-b from-teal-500 to-teal-600 text-white shadow-md shadow-teal-500/20"
-                          : "border-border/60 hover:-translate-y-0.5 hover:border-teal-300 hover:shadow-soft dark:hover:border-teal-700",
+                          ? "border-ocean-400 bg-gradient-to-b from-ocean-500 to-ocean-600 text-white shadow-md shadow-ocean-500/20"
+                          : "border-border/60 hover:-translate-y-0.5 hover:border-ocean-300 hover:shadow-warm dark:hover:border-ocean-700",
                       )}
                     >
                       {n}

--- a/medmate-ai/app/telehealth/page.tsx
+++ b/medmate-ai/app/telehealth/page.tsx
@@ -69,7 +69,6 @@ export default function TelehealthPage() {
 
   async function confirm() {
     setLoading(true);
-    // Placeholder delay — no real booking
     await new Promise((r) => setTimeout(r, 800));
     setLoading(false);
     setStep("confirmed");
@@ -78,11 +77,11 @@ export default function TelehealthPage() {
   return (
     <div className="container max-w-3xl py-10">
       <div className="mb-8 flex items-center gap-3">
-        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-lg shadow-teal-500/25">
+        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-ocean-400 to-ocean-600 text-white shadow-lg shadow-ocean-500/25">
           <Video className="h-6 w-6" />
         </div>
         <div>
-          <h1 className="text-2xl font-bold">Book a telehealth consult</h1>
+          <h1 className="heading text-2xl font-bold">Book a telehealth consult</h1>
           <p className="text-sm text-muted-foreground">
             Video or phone consult with an Australian-registered GP.
           </p>
@@ -126,8 +125,8 @@ export default function TelehealthPage() {
                       className={cn(
                         "rounded-xl border p-3.5 text-left text-sm transition-all duration-200",
                         active
-                          ? "border-teal-400 bg-gradient-to-r from-teal-50 to-teal-50/50 text-teal-700 shadow-glow dark:from-teal-900/30 dark:to-teal-900/10 dark:text-teal-200"
-                          : "border-border/60 hover:-translate-y-0.5 hover:border-teal-300 hover:shadow-soft dark:hover:border-teal-700",
+                          ? "border-ocean-400 bg-gradient-to-r from-ocean-50 to-ocean-50/50 text-ocean-700 shadow-glow dark:from-ocean-900/30 dark:to-ocean-900/10 dark:text-ocean-200"
+                          : "border-border/60 hover:-translate-y-0.5 hover:border-ocean-300 hover:shadow-warm dark:hover:border-ocean-700",
                       )}
                     >
                       <div className="text-xs text-muted-foreground">
@@ -156,7 +155,7 @@ export default function TelehealthPage() {
                   type="checkbox"
                   checked={bulkBilled}
                   onChange={(e) => setBulkBilled(e.target.checked)}
-                  className="h-4 w-4 rounded border-border text-teal-500"
+                  className="h-4 w-4 rounded border-border text-ocean-500"
                 />
                 Yes
               </label>
@@ -232,10 +231,10 @@ export default function TelehealthPage() {
       )}
 
       {step === "confirmed" && selected && (
-        <Card className="border-teal-100 bg-teal-50 dark:border-teal-900/40 dark:bg-teal-950/30">
+        <Card className="border-ocean-100 bg-ocean-50 dark:border-ocean-900/40 dark:bg-ocean-950/30">
           <CardContent className="p-8 text-center">
-            <CheckCircle2 className="mx-auto mb-3 h-10 w-10 text-teal-600" />
-            <h2 className="text-xl font-bold">Booking confirmed</h2>
+            <CheckCircle2 className="mx-auto mb-3 h-10 w-10 text-ocean-600" />
+            <h2 className="heading text-xl font-bold">Booking confirmed</h2>
             <p className="mt-2 text-sm text-muted-foreground">
               Your telehealth consult is booked for{" "}
               <strong>{formatSlot(selected).date}</strong> at{" "}
@@ -272,9 +271,9 @@ function InfoTile({
   body: string;
 }) {
   return (
-    <div className="rounded-xl border border-border/60 bg-card p-4 shadow-soft">
+    <div className="rounded-xl border border-border/60 bg-card p-4 shadow-warm">
       <div className="flex items-center gap-2.5">
-        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-teal-50 text-teal-600 dark:bg-teal-900/40 dark:text-teal-400">
+        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-ocean-50 text-ocean-600 dark:bg-ocean-900/40 dark:text-ocean-400">
           {icon}
         </div>
         <span className="text-sm font-semibold text-foreground">{title}</span>

--- a/medmate-ai/components/chat/chat-composer.tsx
+++ b/medmate-ai/components/chat/chat-composer.tsx
@@ -36,7 +36,7 @@ export function ChatComposer({
         e.preventDefault();
         if (value.trim() && !disabled) onSubmit();
       }}
-      className="flex items-end gap-2 rounded-2xl border border-border/60 bg-card p-2.5 shadow-soft transition-all duration-200 focus-within:border-teal-300 focus-within:shadow-glow dark:focus-within:border-teal-700"
+      className="flex items-end gap-2 rounded-2xl border border-border/60 bg-card p-2.5 shadow-warm transition-all duration-200 focus-within:border-ocean-300 focus-within:shadow-glow dark:focus-within:border-ocean-700"
     >
       <textarea
         ref={ref}
@@ -52,7 +52,7 @@ export function ChatComposer({
         rows={1}
         placeholder={placeholder ?? "Describe your symptoms\u2026"}
         className={cn(
-          "flex-1 resize-none bg-transparent px-2 py-2 text-[15px] outline-none placeholder:text-muted-foreground/50",
+          "flex-1 resize-none bg-transparent px-2 py-2 font-body text-[15px] outline-none placeholder:text-muted-foreground/50",
           "max-h-[200px]",
         )}
       />
@@ -63,7 +63,7 @@ export function ChatComposer({
         className={cn(
           "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl transition-all duration-200",
           value.trim() && !disabled
-            ? "bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-md shadow-teal-500/25 hover:shadow-lg active:scale-95"
+            ? "bg-gradient-to-br from-ocean-400 to-ocean-600 text-white shadow-md shadow-ocean-500/25 hover:shadow-lg active:scale-95"
             : "bg-muted text-muted-foreground",
         )}
       >

--- a/medmate-ai/components/chat/chat-message.tsx
+++ b/medmate-ai/components/chat/chat-message.tsx
@@ -19,21 +19,21 @@ export function ChatMessage({ message, streaming }: Props) {
       className={cn(
         "flex w-full gap-3",
         isUser
-          ? "animate-slide-in-right justify-end"
-          : "animate-slide-in-left justify-start",
+          ? "animate-slide-right justify-end"
+          : "animate-slide-left justify-start",
       )}
     >
       {!isUser && (
-        <div className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-md shadow-teal-500/20">
+        <div className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-ocean-400 to-ocean-600 text-white shadow-md shadow-ocean-500/20">
           <Stethoscope className="h-4 w-4" />
         </div>
       )}
 
       <div
         className={cn(
-          "max-w-[80%] rounded-2xl px-4 py-3 prose-chat shadow-soft",
+          "max-w-[80%] rounded-2xl px-4 py-3 prose-chat shadow-warm",
           isUser
-            ? "rounded-br-md bg-gradient-to-br from-teal-500 to-teal-600 text-white"
+            ? "rounded-br-md bg-gradient-to-br from-ocean-500 to-ocean-600 text-white"
             : "rounded-bl-md border border-border/40 bg-card text-foreground",
         )}
       >
@@ -46,14 +46,14 @@ export function ChatMessage({ message, streaming }: Props) {
             </ReactMarkdown>
             {streaming && message.content === "" && <TypingIndicator />}
             {streaming && message.content !== "" && (
-              <span className="ml-0.5 inline-block h-4 w-[3px] animate-pulse-soft rounded-full bg-teal-500 align-middle" />
+              <span className="ml-0.5 inline-block h-4 w-[3px] animate-pulse-soft rounded-full bg-ocean-500 align-middle" />
             )}
           </>
         )}
       </div>
 
       {isUser && (
-        <div className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-teal-100 to-teal-200 text-teal-700 shadow-sm dark:from-teal-800 dark:to-teal-900 dark:text-teal-100">
+        <div className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-ocean-100 to-ocean-200 text-ocean-700 shadow-sm dark:from-ocean-800 dark:to-ocean-900 dark:text-ocean-100">
           <User className="h-4 w-4" />
         </div>
       )}
@@ -67,9 +67,9 @@ function TypingIndicator() {
       {[0, 1, 2].map((i) => (
         <span
           key={i}
-          className="h-2 w-2 rounded-full bg-teal-400"
+          className="h-2 w-2 rounded-full bg-ocean-400"
           style={{
-            animation: "typing-dot 1.4s ease-in-out infinite",
+            animation: "typing-bounce 1.4s ease-in-out infinite",
             animationDelay: `${i * 0.2}s`,
           }}
         />

--- a/medmate-ai/components/chat/chat-window.tsx
+++ b/medmate-ai/components/chat/chat-window.tsx
@@ -183,9 +183,9 @@ export function ChatWindow({ initialMessages = [], profile = null }: Props) {
               ))}
 
               {showTelehealthCTA && (
-                <div className="mt-2 animate-fade-in rounded-2xl border border-teal-200/60 bg-gradient-to-r from-teal-50 to-teal-50/50 p-4 shadow-soft dark:border-teal-900/40 dark:from-teal-950/30 dark:to-teal-950/10">
+                <div className="mt-2 animate-fade-in rounded-2xl border border-ocean-200/60 bg-gradient-to-r from-ocean-50 to-ocean-50/50 p-4 shadow-warm dark:border-ocean-900/40 dark:from-ocean-950/30 dark:to-ocean-950/10">
                   <div className="flex items-start gap-3">
-                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-sm">
+                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-ocean-400 to-ocean-600 text-white shadow-sm">
                       <Video className="h-4 w-4" />
                     </div>
                     <div className="flex-1">
@@ -219,7 +219,7 @@ export function ChatWindow({ initialMessages = [], profile = null }: Props) {
       </div>
 
       {/* Composer */}
-      <div className="border-t border-border/40 bg-background/60 backdrop-blur-xl">
+      <div className="border-t border-border/40 glass">
         <div className="container max-w-3xl py-4">
           <div className="mb-3 flex items-center justify-between gap-2">
             <Button
@@ -266,15 +266,15 @@ function EmptyState({
   return (
     <div className="flex flex-col items-center py-16 text-center">
       <div className="relative mb-6">
-        <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-lg shadow-teal-500/25 animate-float-gentle">
+        <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-ocean-400 to-ocean-600 text-white shadow-lg shadow-ocean-500/25 animate-float">
           <HeartPulse className="h-8 w-8" />
         </div>
-        <div className="absolute -bottom-1 -right-1 flex h-7 w-7 items-center justify-center rounded-lg bg-amber-400 shadow-md">
+        <div className="absolute -bottom-1 -right-1 flex h-7 w-7 items-center justify-center rounded-lg bg-coral-400 shadow-md">
           <MessageSquareHeart className="h-3.5 w-3.5 text-white" />
         </div>
       </div>
 
-      <h1 className="text-2xl font-bold md:text-3xl">
+      <h1 className="heading text-2xl font-bold md:text-3xl">
         G&apos;day
         {profile?.fullName
           ? `, ${profile.fullName.split(" ")[0]}`
@@ -286,15 +286,15 @@ function EmptyState({
         what might be happening, and suggest a clear next step.
       </p>
 
-      <div className="stagger-children mt-10 grid w-full max-w-xl gap-3 sm:grid-cols-2">
+      <div className="stagger mt-10 grid w-full max-w-xl gap-3 sm:grid-cols-2">
         {SUGGESTIONS.map((s) => (
           <button
             key={s.text}
             onClick={() => onPick(s.text)}
-            className="group animate-fade-in-up rounded-2xl border border-border/60 bg-card p-4 text-left text-sm shadow-soft transition-all duration-200 hover:-translate-y-0.5 hover:border-teal-300 hover:shadow-glow dark:hover:border-teal-700"
+            className="group animate-fade-up rounded-2xl border border-border/60 bg-card p-4 text-left text-sm shadow-warm transition-all duration-200 hover:-translate-y-0.5 hover:border-ocean-300 hover:shadow-glow dark:hover:border-ocean-700"
           >
             <div className="flex items-start gap-2.5">
-              <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-amber-500 transition-transform duration-300 group-hover:scale-110 group-hover:text-teal-500" />
+              <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-coral-500 transition-transform duration-300 group-hover:scale-110 group-hover:text-ocean-500" />
               <span className="leading-relaxed">{s.text}</span>
             </div>
           </button>

--- a/medmate-ai/components/layout/disclaimer-banner.tsx
+++ b/medmate-ai/components/layout/disclaimer-banner.tsx
@@ -4,15 +4,15 @@ export function DisclaimerBanner() {
   return (
     <div
       role="alert"
-      className="w-full border-b border-amber-200/60 bg-gradient-to-r from-amber-50 via-amber-50/80 to-amber-50 px-4 py-2 text-center text-xs text-amber-900 dark:border-amber-900/30 dark:from-amber-950/50 dark:via-amber-950/30 dark:to-amber-950/50 dark:text-amber-200"
+      className="w-full border-b border-coral-200/60 bg-gradient-to-r from-coral-50 via-coral-50/80 to-coral-50 px-4 py-2 text-center text-xs text-coral-900 dark:border-coral-900/30 dark:from-coral-950/50 dark:via-coral-950/30 dark:to-coral-950/50 dark:text-coral-200"
     >
       <div className="container flex items-center justify-center gap-2">
-        <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-500" aria-hidden />
+        <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-coral-500" aria-hidden />
         <p>
           <strong>Medical emergency?</strong> Call{" "}
           <a
             href="tel:000"
-            className="inline-flex items-center gap-0.5 font-bold underline decoration-amber-400 underline-offset-2 transition-colors hover:text-amber-700 dark:decoration-amber-600 dark:hover:text-amber-100"
+            className="inline-flex items-center gap-0.5 font-bold underline decoration-coral-400 underline-offset-2 transition-colors hover:text-coral-700 dark:decoration-coral-600 dark:hover:text-coral-100"
           >
             <Phone className="h-3 w-3" />
             000

--- a/medmate-ai/components/layout/footer.tsx
+++ b/medmate-ai/components/layout/footer.tsx
@@ -47,12 +47,12 @@ export function Footer() {
           {/* Brand */}
           <div className="md:col-span-2">
             <div className="flex items-center gap-2.5">
-              <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-md shadow-teal-500/20">
+              <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-ocean-400 to-ocean-600 text-white shadow-md shadow-ocean-500/20">
                 <Stethoscope className="h-5 w-5" />
               </span>
-              <span className="text-lg font-bold tracking-tight">
+              <span className="text-lg font-bold font-display tracking-tight">
                 MedMate{" "}
-                <span className="bg-gradient-to-r from-teal-500 to-teal-400 bg-clip-text text-transparent">
+                <span className="bg-gradient-to-r from-ocean-500 to-ocean-400 bg-clip-text text-transparent">
                   AI
                 </span>
               </span>
@@ -76,7 +76,7 @@ export function Footer() {
 
           {/* Links */}
           <div>
-            <h4 className="text-sm font-semibold">MedMate</h4>
+            <h4 className="text-sm font-semibold font-display">MedMate</h4>
             <ul className="mt-4 space-y-2.5 text-sm text-muted-foreground">
               {[
                 { href: "/chat", label: "AI Chat" },
@@ -88,7 +88,7 @@ export function Footer() {
                 <li key={link.href}>
                   <Link
                     href={link.href}
-                    className="transition-colors hover:text-teal-600 dark:hover:text-teal-400"
+                    className="transition-colors hover:text-ocean-600 dark:hover:text-ocean-400"
                   >
                     {link.label}
                   </Link>
@@ -99,7 +99,7 @@ export function Footer() {
 
           {/* Helplines */}
           <div>
-            <h4 className="text-sm font-semibold">Australian helplines</h4>
+            <h4 className="text-sm font-semibold font-display">Australian helplines</h4>
             <ul className="mt-4 space-y-3 text-sm">
               {helplines.map((h) => (
                 <li key={h.name}>
@@ -111,7 +111,7 @@ export function Footer() {
                       className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md ${
                         h.urgent
                           ? "bg-red-100 text-red-600 dark:bg-red-900/40 dark:text-red-400"
-                          : "bg-teal-50 text-teal-500 dark:bg-teal-900/40 dark:text-teal-400"
+                          : "bg-ocean-50 text-ocean-500 dark:bg-ocean-900/40 dark:text-ocean-400"
                       }`}
                     >
                       <Phone className="h-3 w-3" />
@@ -135,7 +135,7 @@ export function Footer() {
         <div className="mt-12 flex flex-col items-start justify-between gap-3 border-t border-border/40 pt-6 text-xs text-muted-foreground md:flex-row md:items-center">
           <p className="flex items-center gap-1.5">
             &copy; {new Date().getFullYear()} MedMate AI. Made with{" "}
-            <Heart className="h-3 w-3 text-red-400" /> in Australia.
+            <Heart className="h-3 w-3 text-coral-400" /> in Australia.
           </p>
           <div className="flex gap-4">
             <Link

--- a/medmate-ai/components/layout/nav.tsx
+++ b/medmate-ai/components/layout/nav.tsx
@@ -27,19 +27,19 @@ export function Nav() {
   const [open, setOpen] = useState(false);
 
   return (
-    <header className="sticky top-0 z-40 border-b border-border/40 bg-background/60 backdrop-blur-2xl backdrop-saturate-150">
+    <header className="sticky top-0 z-40 glass border-b border-border/40">
       <div className="container flex h-16 items-center justify-between">
         {/* Logo */}
         <Link
           href="/"
           className="group flex items-center gap-2.5 text-lg font-bold tracking-tight"
         >
-          <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-teal-400 to-teal-600 text-white shadow-md shadow-teal-500/25 transition-transform duration-200 group-hover:scale-105">
+          <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-ocean-400 to-ocean-600 text-white shadow-md shadow-ocean-500/25 transition-transform duration-200 group-hover:scale-105">
             <Stethoscope className="h-5 w-5" />
           </span>
-          <span className="flex items-baseline gap-0.5">
+          <span className="flex items-baseline gap-0.5 font-display">
             MedMate{" "}
-            <span className="bg-gradient-to-r from-teal-500 to-teal-400 bg-clip-text text-transparent">
+            <span className="bg-gradient-to-r from-ocean-500 to-ocean-400 bg-clip-text text-transparent">
               AI
             </span>
           </span>
@@ -56,7 +56,7 @@ export function Nav() {
                 className={cn(
                   "relative flex items-center gap-1.5 rounded-xl px-3.5 py-2 text-sm font-medium transition-all duration-200",
                   active
-                    ? "bg-teal-50 text-teal-700 shadow-sm dark:bg-teal-900/30 dark:text-teal-200"
+                    ? "bg-ocean-50 text-ocean-700 shadow-sm dark:bg-ocean-900/30 dark:text-ocean-200"
                     : "text-muted-foreground hover:bg-accent hover:text-foreground",
                 )}
               >
@@ -85,7 +85,7 @@ export function Nav() {
           onClick={() => setOpen((v) => !v)}
           className={cn(
             "inline-flex h-10 w-10 items-center justify-center rounded-xl transition-colors md:hidden",
-            open ? "bg-teal-50 text-teal-700" : "hover:bg-accent",
+            open ? "bg-ocean-50 text-ocean-700" : "hover:bg-accent",
           )}
         >
           {open ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
@@ -106,7 +106,7 @@ export function Nav() {
                   className={cn(
                     "flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium transition-colors",
                     active
-                      ? "bg-teal-50 text-teal-700 dark:bg-teal-900/30 dark:text-teal-200"
+                      ? "bg-ocean-50 text-ocean-700 dark:bg-ocean-900/30 dark:text-ocean-200"
                       : "hover:bg-accent",
                   )}
                 >

--- a/medmate-ai/components/ui/badge.tsx
+++ b/medmate-ai/components/ui/badge.tsx
@@ -3,16 +3,16 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold transition-colors",
+  "inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold font-body transition-colors",
   {
     variants: {
       variant: {
         default:
-          "border-transparent bg-gradient-to-r from-teal-500 to-teal-600 text-white shadow-sm",
+          "border-transparent bg-gradient-to-r from-ocean-500 to-ocean-600 text-white shadow-sm",
         secondary:
-          "border-teal-200/60 bg-teal-50 text-teal-700 dark:border-teal-800/60 dark:bg-teal-900/40 dark:text-teal-200",
-        amber:
-          "border-amber-200/60 bg-amber-50 text-amber-800 dark:border-amber-800/60 dark:bg-amber-900/40 dark:text-amber-200",
+          "border-ocean-200/60 bg-ocean-50 text-ocean-700 dark:border-ocean-800/60 dark:bg-ocean-900/40 dark:text-ocean-200",
+        coral:
+          "border-coral-200/60 bg-coral-50 text-coral-800 dark:border-coral-800/60 dark:bg-coral-900/40 dark:text-coral-200",
         outline:
           "border-border text-foreground",
         destructive:

--- a/medmate-ai/components/ui/button.tsx
+++ b/medmate-ai/components/ui/button.tsx
@@ -3,29 +3,30 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl text-sm font-semibold ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 active:scale-[0.97]",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap font-body text-sm font-semibold transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ocean-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 active:scale-[0.97]",
   {
     variants: {
       variant: {
         default:
-          "bg-gradient-to-b from-teal-500 to-teal-600 text-white shadow-md shadow-teal-500/20 hover:from-teal-400 hover:to-teal-600 hover:shadow-lg hover:shadow-teal-500/30 active:from-teal-600 active:to-teal-700",
+          "rounded-xl bg-ocean-500 text-white shadow-md shadow-ocean-500/15 hover:bg-ocean-600 hover:shadow-warm-lg",
+        coral:
+          "rounded-xl bg-coral-500 text-white shadow-md shadow-coral-500/15 hover:bg-coral-600 hover:shadow-lg hover:shadow-coral-500/20",
         secondary:
-          "bg-teal-50 text-teal-700 shadow-sm hover:bg-teal-100 hover:shadow-md dark:bg-teal-900/40 dark:text-teal-100 dark:hover:bg-teal-800/60",
-        amber:
-          "bg-gradient-to-b from-amber-400 to-amber-500 text-white shadow-md shadow-amber-500/20 hover:from-amber-400 hover:to-amber-600 hover:shadow-lg hover:shadow-amber-500/30",
+          "rounded-xl bg-ocean-50 text-ocean-700 shadow-sm hover:bg-ocean-100 dark:bg-ocean-900/40 dark:text-ocean-200 dark:hover:bg-ocean-800/60",
         outline:
-          "border-2 border-border bg-background hover:border-teal-300 hover:bg-teal-50/50 hover:text-teal-700 dark:hover:border-teal-700 dark:hover:bg-teal-900/20 dark:hover:text-teal-200",
+          "rounded-xl border-2 border-border bg-transparent hover:border-ocean-300 hover:bg-ocean-50/50 hover:text-ocean-700 dark:hover:border-ocean-700 dark:hover:bg-ocean-950/30",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground",
+          "rounded-xl hover:bg-accent hover:text-accent-foreground",
         destructive:
-          "bg-gradient-to-b from-red-500 to-red-600 text-white shadow-sm shadow-red-500/20 hover:from-red-400 hover:to-red-600",
-        link: "text-teal-600 underline-offset-4 hover:underline dark:text-teal-400",
+          "rounded-xl bg-red-500 text-white shadow-sm hover:bg-red-600",
+        link:
+          "text-ocean-600 underline-offset-4 hover:underline dark:text-ocean-400",
       },
       size: {
         default: "h-10 px-5 py-2",
-        sm: "h-8 rounded-lg px-3 text-xs",
+        sm: "h-8 rounded-lg px-3.5 text-xs",
         lg: "h-12 rounded-xl px-7 text-base",
-        xl: "h-14 rounded-2xl px-8 text-base",
+        xl: "h-14 rounded-2xl px-8 text-base tracking-wide",
         icon: "h-10 w-10 rounded-xl",
       },
     },

--- a/medmate-ai/components/ui/card.tsx
+++ b/medmate-ai/components/ui/card.tsx
@@ -8,7 +8,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-2xl border border-border/60 bg-card text-card-foreground shadow-soft transition-all duration-300",
+      "rounded-2xl border border-border/50 bg-card text-card-foreground shadow-warm transition-all duration-300",
       className,
     )}
     {...props}
@@ -35,7 +35,7 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
+      "heading text-lg font-semibold leading-none",
       className,
     )}
     {...props}

--- a/medmate-ai/components/ui/input.tsx
+++ b/medmate-ai/components/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-xl border border-border bg-background px-3.5 py-2 text-sm shadow-sm transition-all duration-200 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/60 hover:border-teal-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500/30 focus-visible:border-teal-400 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:border-teal-700",
+          "flex h-10 w-full rounded-xl border border-border bg-background px-3.5 py-2 font-body text-sm shadow-sm transition-all duration-200 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground/60 hover:border-ocean-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ocean-500/30 focus-visible:border-ocean-400 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:border-ocean-700",
           className,
         )}
         ref={ref}

--- a/medmate-ai/components/ui/textarea.tsx
+++ b/medmate-ai/components/ui/textarea.tsx
@@ -8,7 +8,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[80px] w-full rounded-xl border border-border bg-background px-3.5 py-2.5 text-sm shadow-sm transition-all duration-200 placeholder:text-muted-foreground/60 hover:border-teal-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500/30 focus-visible:border-teal-400 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:border-teal-700",
+          "flex min-h-[80px] w-full rounded-xl border border-border bg-background px-3.5 py-2.5 font-body text-sm shadow-sm transition-all duration-200 placeholder:text-muted-foreground/60 hover:border-ocean-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ocean-500/30 focus-visible:border-ocean-400 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:border-ocean-700",
           className,
         )}
         ref={ref}

--- a/medmate-ai/tailwind.config.ts
+++ b/medmate-ai/tailwind.config.ts
@@ -16,6 +16,7 @@ const config: Config = {
     },
     extend: {
       colors: {
+        /* Semantic tokens */
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
@@ -45,31 +46,50 @@ const config: Config = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
-        teal: {
-          DEFAULT: "#0D7377",
-          50: "#E6F4F4",
-          100: "#CCEAEA",
-          200: "#99D4D6",
-          300: "#66BFC1",
-          400: "#33A9AC",
-          500: "#0D7377",
-          600: "#0A5C5F",
-          700: "#084547",
-          800: "#052E30",
-          900: "#031718",
+        /* Brand palette — warm editorial teal + coral */
+        ocean: {
+          50: "#EFF8F8",
+          100: "#D7EFEF",
+          200: "#AFDEDE",
+          300: "#7BC8C8",
+          400: "#47ADAD",
+          500: "#0B6E6E",
+          600: "#095A5A",
+          700: "#074646",
+          800: "#053232",
+          900: "#031E1E",
+          950: "#011010",
         },
-        amber: {
-          DEFAULT: "#F59E0B",
-          50: "#FFFBEB",
-          100: "#FEF3C7",
-          200: "#FDE68A",
-          300: "#FCD34D",
-          400: "#FBBF24",
-          500: "#F59E0B",
-          600: "#D97706",
-          700: "#B45309",
-          800: "#92400E",
-          900: "#78350F",
+        coral: {
+          50: "#FFF5F2",
+          100: "#FFE8E1",
+          200: "#FFD0C3",
+          300: "#FFB09A",
+          400: "#F08B6D",
+          500: "#E8735A",
+          600: "#D15A42",
+          700: "#B04432",
+          800: "#8C3528",
+          900: "#6B2A20",
+        },
+        sage: {
+          50: "#F2F7F2",
+          100: "#E0EDE0",
+          200: "#C2DBC2",
+          300: "#97C197",
+          400: "#6BA66B",
+          500: "#4A8C4A",
+          600: "#3A7040",
+          700: "#2D5632",
+          800: "#234426",
+          900: "#1A331C",
+        },
+        cream: {
+          50: "#FEFCFA",
+          100: "#FDF6F0",
+          200: "#FBEEE2",
+          300: "#F5DEC8",
+          400: "#EDCBA8",
         },
       },
       borderRadius: {
@@ -78,76 +98,71 @@ const config: Config = {
         sm: "calc(var(--radius) - 4px)",
       },
       fontFamily: {
-        sans: ["var(--font-inter)", "system-ui", "sans-serif"],
+        display: ["var(--font-display)", "Georgia", "serif"],
+        body: ["var(--font-body)", "system-ui", "sans-serif"],
       },
       boxShadow: {
-        glow: "0 0 20px rgba(13, 115, 119, 0.15)",
-        "glow-lg": "0 0 40px rgba(13, 115, 119, 0.2)",
-        soft: "0 2px 8px rgba(0,0,0,0.04), 0 4px 24px rgba(0,0,0,0.06)",
-        "soft-lg":
-          "0 4px 12px rgba(0,0,0,0.05), 0 8px 32px rgba(0,0,0,0.08)",
-        float:
-          "0 8px 30px rgba(0,0,0,0.06), 0 2px 8px rgba(0,0,0,0.04)",
+        warm: "0 2px 10px rgba(11,110,110,0.06), 0 8px 30px rgba(11,110,110,0.04)",
+        "warm-lg":
+          "0 4px 16px rgba(11,110,110,0.08), 0 12px 40px rgba(11,110,110,0.06)",
+        "warm-xl":
+          "0 8px 24px rgba(11,110,110,0.1), 0 20px 60px rgba(11,110,110,0.08)",
+        glow: "0 0 24px rgba(11,110,110,0.15)",
+        "coral-glow": "0 0 24px rgba(232,115,90,0.2)",
+        inner: "inset 0 2px 4px rgba(0,0,0,0.04)",
       },
       keyframes: {
+        "fade-up": {
+          "0%": { opacity: "0", transform: "translateY(20px)" },
+          "100%": { opacity: "1", transform: "translateY(0)" },
+        },
         "fade-in": {
-          "0%": { opacity: "0", transform: "translateY(6px)" },
-          "100%": { opacity: "1", transform: "translateY(0)" },
+          "0%": { opacity: "0" },
+          "100%": { opacity: "1" },
         },
-        "fade-in-up": {
-          "0%": { opacity: "0", transform: "translateY(16px)" },
-          "100%": { opacity: "1", transform: "translateY(0)" },
-        },
-        "fade-in-scale": {
-          "0%": { opacity: "0", transform: "scale(0.95)" },
-          "100%": { opacity: "1", transform: "scale(1)" },
-        },
-        "slide-in-right": {
-          "0%": { opacity: "0", transform: "translateX(12px)" },
+        "slide-right": {
+          "0%": { opacity: "0", transform: "translateX(16px)" },
           "100%": { opacity: "1", transform: "translateX(0)" },
         },
-        "slide-in-left": {
-          "0%": { opacity: "0", transform: "translateX(-12px)" },
+        "slide-left": {
+          "0%": { opacity: "0", transform: "translateX(-16px)" },
           "100%": { opacity: "1", transform: "translateX(0)" },
+        },
+        float: {
+          "0%, 100%": { transform: "translateY(0)" },
+          "50%": { transform: "translateY(-8px)" },
         },
         "pulse-soft": {
           "0%, 100%": { opacity: "1" },
           "50%": { opacity: "0.4" },
         },
-        "typing-dot": {
-          "0%, 60%, 100%": { opacity: "0.3", transform: "scale(0.8)" },
-          "30%": { opacity: "1", transform: "scale(1)" },
+        "typing-bounce": {
+          "0%, 60%, 100%": { transform: "translateY(0)", opacity: "0.4" },
+          "30%": { transform: "translateY(-4px)", opacity: "1" },
+        },
+        "blob-morph": {
+          "0%, 100%": { borderRadius: "60% 40% 30% 70% / 60% 30% 70% 40%" },
+          "50%": { borderRadius: "30% 60% 70% 40% / 50% 60% 30% 60%" },
         },
         shimmer: {
           "0%": { backgroundPosition: "-200% 0" },
           "100%": { backgroundPosition: "200% 0" },
         },
-        "float-gentle": {
-          "0%, 100%": { transform: "translateY(0)" },
-          "50%": { transform: "translateY(-6px)" },
-        },
-        "gradient-shift": {
-          "0%, 100%": { backgroundPosition: "0% 50%" },
-          "50%": { backgroundPosition: "100% 50%" },
+        "scale-in": {
+          "0%": { opacity: "0", transform: "scale(0.92)" },
+          "100%": { opacity: "1", transform: "scale(1)" },
         },
       },
       animation: {
-        "fade-in": "fade-in 0.3s ease-out",
-        "fade-in-up": "fade-in-up 0.5s ease-out",
-        "fade-in-scale": "fade-in-scale 0.3s ease-out",
-        "slide-in-right": "slide-in-right 0.3s ease-out",
-        "slide-in-left": "slide-in-left 0.3s ease-out",
+        "fade-up": "fade-up 0.6s cubic-bezier(0.16,1,0.3,1) both",
+        "fade-in": "fade-in 0.4s ease-out both",
+        "slide-right": "slide-right 0.4s cubic-bezier(0.16,1,0.3,1) both",
+        "slide-left": "slide-left 0.4s cubic-bezier(0.16,1,0.3,1) both",
+        float: "float 5s ease-in-out infinite",
         "pulse-soft": "pulse-soft 1.5s ease-in-out infinite",
+        "blob-morph": "blob-morph 8s ease-in-out infinite",
         shimmer: "shimmer 2s linear infinite",
-        "float-gentle": "float-gentle 4s ease-in-out infinite",
-        "gradient-shift": "gradient-shift 6s ease infinite",
-      },
-      backgroundImage: {
-        "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-        "hero-pattern":
-          "radial-gradient(ellipse 80% 50% at 50% -20%, rgba(13,115,119,0.12), transparent)",
-        "hero-pattern-dark":
-          "radial-gradient(ellipse 80% 50% at 50% -20%, rgba(13,115,119,0.25), transparent)",
+        "scale-in": "scale-in 0.3s cubic-bezier(0.16,1,0.3,1) both",
       },
     },
   },


### PR DESCRIPTION
Complete visual overhaul using Fraunces + DM Sans typography, ocean/coral/sage/cream palette replacing teal/amber, film grain texture, organic blob shapes, mesh gradients, warm glass nav, and editorial heading styles across all 21 files.

https://claude.ai/code/session_01WQEGJAZax1SyRwSBzrb3LM